### PR TITLE
Fix comment in example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ use Middlewares\Utils\Dispatcher;
 
 // Create a new ErrorHandler instance
 // Any number of formatters can be added. One will be picked based on the Accept
-// header of the request. If no formatter matches, the PlainFormatter will be used.
+// header of the request. If no formatter matches, the first formatter in the array
+// will be used.
 $errorHandler = new ErrorHandler([
     new ErrorFormatter\HtmlFormatter(),
     new ErrorFormatter\ImageFormatter(),


### PR DESCRIPTION
The comment claims that the ErrorHandler falls back to the PlainFormatter, when no Formatter matches the request, but that is not true. It falls back to the first formatter in the list. When you do not supply any formatters to the constructor the default list of formatters indeed starts with the PlainFormatter, but that is not what happens in the example.