### PR TITLE
Support "Allow" header for 405 errors

### DIFF
--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -56,6 +56,28 @@ class ErrorHandlerTest extends TestCase
         $this->assertEquals(418, $response->getStatusCode());
     }
 
+    public function testNotAllowedException()
+    {
+        $response = Dispatcher::run([
+            new ErrorHandler(),
+            function ($request) {
+                throw new class() extends Exception {
+                    public function getStatusCode(): int
+                    {
+                        return 405;
+                    }
+                    public function getContext(): array
+                    {
+                        return ['allow' => ['GET', 'POST']];
+                    }
+                };
+            },
+        ]);
+
+        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertEquals('GET, POST', $response->getHeaderLine('Allow'));
+    }
+
     public function testGifFormatter()
     {
         $request = Factory::createServerRequest('GET', '/');


### PR DESCRIPTION
> The HTTP `405 Method Not Allowed` client error response status code indicates that the server knows the request method, but the target resource doesn't support this method. The server ***must*** generate an Allow header in a 405 response with a list of methods that the target resource currently supports.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405