### PR TITLE
Add support for an optional onError callback

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,6 @@
 .gitattributes       export-ignore
 .gitignore           export-ignore
 .php-cs-fixer.php    export-ignore
-phpcs.xml.dist       export-ignore
-phpunit.xml.dist     export-ignore
+phpcs.xml            export-ignore
+phpunit.xml          export-ignore
 .phpstan.neon        export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.0] - 2025-04-22
+### Added
+- Support for [PSR-3 Logger](https://github.com/php-fig/log). Example using [Monolog](https://github.com/Seldaek/monolog):
+
+With default logging:
+```php
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+$logger = new Logger('app');
+$logger->pushHandler(new StreamHandler('path/to/your.log', Level::Warning));
+
+$response = Dispatcher::run([
+    new ErrorHandler(null, $logger),
+    function ($request) {
+        throw new Exception('Something went wrong');
+    },
+]);
+
+```
+With a custom log callback:
+```php
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+
+$logger = new Logger('app');
+$logger->pushHandler(new StreamHandler('path/to/your.log', Level::Warning));
+
+$response = Dispatcher::run([
+    (new ErrorHandler(null, $logger))
+        ->logCallback(function (
+            LoggerInterface $logger,
+            Throwable $error,
+            ServerRequestInterface $request
+        ): void {
+            $logger->critical('Uncaught exception', [
+                'message' => $error->getMessage(),
+                'request' => [
+                    'uri' => $request->getUri()->getPath(),
+                ]
+            ]);
+        }),
+    function ($request) {
+        throw new Exception('Something went wrong');
+    },
+]);
+```
+
 ## [3.1.0] - 2025-03-21
 ### Fixed
 - Support for PHP typing.
@@ -117,6 +167,7 @@ First version
 
 [#9]: https://github.com/middlewares/error-handler/issues/9
 
+[3.2.0]: https://github.com/middlewares/error-handler/compare/v3.1.0...v3.2.0
 [3.1.0]: https://github.com/middlewares/error-handler/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/middlewares/error-handler/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/middlewares/error-handler/compare/v3.0.0...v3.0.1

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,10 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
+        "ext-gd": "*",
         "middlewares/utils": "^2 || ^3 || ^4",
         "psr/http-server-middleware": "^1",
-        "ext-gd": "*"
+        "psr/log": "^1 || ^2 || ^3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8 || ^9",
@@ -30,7 +31,8 @@
         "squizlabs/php_codesniffer": "^3",
         "oscarotero/php-cs-fixer-config": "^2",
         "phpstan/phpstan": "^1 || ^2",
-        "laminas/laminas-diactoros": "^2 || ^3"
+        "laminas/laminas-diactoros": "^2 || ^3",
+        "filisko/fake-psr3-logger": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "squizlabs/php_codesniffer": "^3",
         "oscarotero/php-cs-fixer-config": "^2",
         "phpstan/phpstan": "^1 || ^2",
-        "laminas/laminas-diactoros": "^2 || ^3"
+        "laminas/laminas-diactoros": "^2 || ^3",
+        "filisko/fake-psr3-logger": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -14,6 +14,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class ErrorHandler implements MiddlewareInterface
@@ -21,13 +22,21 @@ class ErrorHandler implements MiddlewareInterface
     /** @var FormatterInterface[] */
     private $formatters = [];
 
+    /** @var LoggerInterface|null */
+    private $logger = null;
+
+    /** @var callable|null */
+    private $logCallback = null;
+
     /**
      * Configure the error formatters
      *
      * @param FormatterInterface[] $formatters
      */
-    public function __construct(?array $formatters = null)
+    public function __construct(?array $formatters = null, ?LoggerInterface $logger = null)
     {
+        $this->logger = $logger;
+
         if (empty($formatters)) {
             $formatters = [
                 new PlainFormatter(),
@@ -54,11 +63,33 @@ class ErrorHandler implements MiddlewareInterface
         return $this;
     }
 
+    /**
+     * @param callable $callback
+     */
+    public function logCallback(callable $callback): self
+    {
+        $this->logCallback = $callback;
+
+        return $this;
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         try {
             return $handler->handle($request);
         } catch (Throwable $error) {
+            if ($this->logger) {
+                if ($this->logCallback) {
+                    ($this->logCallback)($this->logger, $error, $request);
+                } else {
+                    $this->logger->critical('Uncaught exception', [
+                        'message' => $error->getMessage(),
+                        'file' => $error->getFile(),
+                        'line' => $error->getLine(),
+                    ]);
+                }
+            }
+
             foreach ($this->formatters as $formatter) {
                 if ($formatter->isValid($error, $request)) {
                     return $formatter->handle($error, $request);


### PR DESCRIPTION
Hi,

This adds support for an optional PSR-3 compliant logger.

The logger is passed as an optional parameter to the constructor. And it also includes a `logCallback` option to fully customize how logging happens (see the changelog and readme).

Thanks!